### PR TITLE
Not adding source if it is null

### DIFF
--- a/logger-discord-provider/DiscordLogger.cs
+++ b/logger-discord-provider/DiscordLogger.cs
@@ -93,7 +93,10 @@ namespace JNogueira.Logger.Discord
             if (exception != null)
             {
                 fields.Add(new DiscordMessageEmbedField("Exception type", exception.GetType().ToString()));
-                fields.Add(new DiscordMessageEmbedField("Source", exception.Source));
+                if (exception.Source != null)
+                {
+                    fields.Add(new DiscordMessageEmbedField("Source", exception.Source));
+                }
 
                 var exceptionInfoText = new StringBuilder();
 


### PR DESCRIPTION
Fixes https://github.com/jlnpinheiro/logger-discord-provider/issues/1

If the exception does not have the `Source` variable set, it still passes it into the fields to be sent to discord. Discord then returns a 400 from this null. Now with this if statement, it just ignores it and continues to run/log it without that little bit of information.

Here is my test code I was using to test the fix.
```cs
// This line used to throw 400
_logger.LogError(new ArgumentNullException("FakeArg"), "Test Error that was caught");
try
{
    throw new ArithmeticException("Test Error that was caught");
}
catch (Exception e)
{
    // This works normally
    _logger.LogError(e, "Caught exception");
}
```
![image](https://github.com/user-attachments/assets/dcd0f9d7-b141-410d-8f06-8cb2b909ffa7)
